### PR TITLE
feat: allow subtitles to be none for theses without a subtitle

### DIFF
--- a/src/for-diva.typ
+++ b/src/for-diva.typ
@@ -50,7 +50,7 @@
 #let serialize-title(lang, info) = {
   (
     "Main title": info.at("title"),
-    "Subtitle": info.at("subtitle"),
+    "Subtitle": info.at("subtitle", default: ""),
     "Language": info.at("alpha-3", default: serialize-lang(lang)),
   )
 }

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -20,11 +20,12 @@
     text(size: 25pt, strong(title))
 
     v(10pt)
-    if subtitle != none {
-      text(size: 18pt, subtitle)
-    } else {
-      text(size: 18pt, "")
+
+    if subtitle == none {
+      subtitle = "" // take up vertical space, but don't print anything
     }
+
+    text(size: 18pt, subtitle)
 
     v(10mm)
 

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -4,7 +4,7 @@
   title: "Primary Language Title Goes Here",
   subtitle: "Primary Language Subtitle Goes Here",
   alt-title: "Alternative Language Title Goes Here",
-  alt-subtitle: "Alternative Language Title Goes Here",
+  alt-subtitle: "Alternative Language Subtitle Goes Here", // may be none!
   alt-lang: "sv", // either "en" or "sv"
   degree: "Master's Program, Computer Science",
   date: datetime.today(),
@@ -63,7 +63,9 @@
 
     [
       *#t("alt-title"):* #text(lang: alt-lang, alt-title) \
-      *#t("alt-subtitle"):* #text(lang: alt-lang, alt-subtitle)
+      #if alt-subtitle != none {
+        [*#t("alt-subtitle"):* #text(lang: alt-lang, alt-subtitle)]
+      }
     ]
   },
 )

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -2,7 +2,7 @@
 
 #let title-page(
   title: "Primary Language Title Goes Here",
-  subtitle: "Primary Language Subtitle Goes Here",
+  subtitle: "Primary Language Subtitle Goes Here", // may be none!
   alt-title: "Alternative Language Title Goes Here",
   alt-subtitle: "Alternative Language Subtitle Goes Here", // may be none!
   alt-lang: "sv", // either "en" or "sv"
@@ -20,8 +20,11 @@
     text(size: 25pt, strong(title))
 
     v(10pt)
-
-    text(size: 18pt, subtitle)
+    if subtitle != none {
+      text(size: 18pt, subtitle)
+    } else {
+      text(size: 18pt, "")
+    }
 
     v(10mm)
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -11,6 +11,7 @@
   // Grouped by language, with only values for "en" and "sv" being mandatory.
   // Localized abstract/keywords headings may be omitted only for "en" and "sv".
   // Field "alpha-3" is the language's ISO 639-3 code, for non-"en"/"sv" langs.
+  // If desired, any "subtitle" field may be set to none (to omit it entirely).
   localized-info: (
     en: (
       title: "How to Abandon Dinosaur-Age TypeSetting Software",

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -11,6 +11,10 @@
   let title = info.at("title")
   let subtitle = info.at("subtitle")
 
+  if subtitle == none {
+    return title
+  }
+
   // I don't really understand why this is the intended behavior either...
   if lang == "sv" {
     title + " - " + subtitle

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -21,6 +21,7 @@
   // Grouped by language, with only values for "en" and "sv" being mandatory.
   // Localized abstract/keywords headings may be omitted only for "en" and "sv".
   // Field "alpha-3" is the language's ISO 639-3 code, for non-"en"/"sv" langs.
+  // If desired, any "subtitle" field may be set to none (to omit it entirely).
   localized-info: (
     en: (
       title: "How to Abandon Dinosaur-Age TypeSetting Software",


### PR DESCRIPTION
Adds functionality for alt-subtitle to not be rendered if it's set to none and updates commented documentation :)

Before the workaround of setting it to "" would still display, for example, "**Swedish subtitle:** "

IDK if something similar can be added for the primary language subtitle or if that messes up the vertical formatting. 