### PR TITLE
fix: improve handling of no subtitle

### DIFF
--- a/src/covers.typ
+++ b/src/covers.typ
@@ -29,7 +29,10 @@
 
       #text(size: 26pt, strong(title)) \
       \
-      #text(size: 16pt, subtitle) \
+      #if subtitle != none [
+        text(size: 16pt, subtitle)
+        \
+      ]
 
       \
     ]

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -19,9 +19,9 @@
   {
     text(size: 25pt, strong(title))
 
-    v(10pt)
-
     if subtitle != none {
+      v(10pt)
+
       text(size: 18pt, subtitle)
     }
 

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -21,11 +21,9 @@
 
     v(10pt)
 
-    if subtitle == none {
-      subtitle = "" // take up vertical space, but don't print anything
+    if subtitle != none {
+      text(size: 18pt, subtitle)
     }
-
-    text(size: 18pt, subtitle)
 
     v(10mm)
 

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -171,7 +171,7 @@
 
   front-cover(
     title: primary-info.at("title"),
-    subtitle: primary-info.at("subtitle"),
+    subtitle: primary-info.at("subtitle", default: none),
     authors: author-names,
     subject-area: degree.at("subject-area"),
     cycle: degree.at("cycle"),
@@ -182,9 +182,9 @@
 
   title-page(
     title: primary-info.at("title"),
-    subtitle: primary-info.at("subtitle"),
+    subtitle: primary-info.at("subtitle", default: none),
     alt-title: alt-info.at("title"),
-    alt-subtitle: alt-info.at("subtitle"),
+    alt-subtitle: alt-info.at("subtitle", default: none),
     alt-lang: alt-lang,
     degree: degree.at("name"),
     date: doc-date,

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -9,7 +9,7 @@
 
 #let get-one-liner(lang, info) = {
   let title = info.at("title")
-  let subtitle = info.at("subtitle")
+  let subtitle = info.at("subtitle", default: none)
 
   if subtitle == none {
     return title


### PR DESCRIPTION
Changes boils down to adding `default: none` at a number of places where the `subtitle` field is accessed. Additionally changes the handling of the display of subtitle to be explicit when it exists. If subtitle should take up the space in either case, as a stylistic choice, let me know and I'll amend that.