### PR TITLE
feat: Use Arial font for covers if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,9 @@ from the provided DOTX templates, but future bids at refining fidelity may be
 attempted in the future, especially if and when LaTeX versions are published.
 
 The covers use Arial, which is a proprietary font and may be difficult to get
-access to. If Arial is available it will be used, otherwise it is replaced
-by an open, metric-compatible substitute; Liberation Sans.
+access to. This template will use Arial if it is available on the system at
+compile-time; otherwise, it will be replaced by an open, metric-compatible
+substitute: Liberation Sans.
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -126,8 +126,9 @@ Covers (June 2024 version) have been replicated as best as possible in Typst
 from the provided DOTX templates, but future bids at refining fidelity may be
 attempted in the future, especially if and when LaTeX versions are published.
 
-The covers use Arial, which is a proprietary font and so has here been replaced
-by an open, metric-compatible substitute: Liberation Sans.
+The covers use Arial, which is a proprietary font and may be difficult to get
+access to. If Arial is available it will be used, otherwise it is replaced
+by an open, metric-compatible substitute; Liberation Sans.
 
 ## Licensing
 

--- a/src/covers.typ
+++ b/src/covers.typ
@@ -11,7 +11,8 @@
   margin: (top: 12.5mm, rest: 25mm),
   {
     set align(center)
-    set text(size: 12pt, font: "Liberation Sans") // Arial is proprietary...
+    // Prioritize Arial if available, otherwise use Liberation Sans
+    set text(size: 12pt, font: ("Arial", "Liberation Sans"))
 
     image("../assets/KTH_logo_RGB_bla.svg", width: 37.45mm)
 
@@ -48,7 +49,8 @@
 ) = page(
   margin: (top: 65mm, bottom: 30mm, left: 74pt, right: 35mm),
   {
-    set text(size: 12pt, font: "Liberation Sans") // Arial is proprietary...
+    // Prioritize Arial if available, otherwise use Liberation Sans
+    set text(size: 12pt, font: ("Arial", "Liberation Sans"))
 
     v(1fr)
 


### PR DESCRIPTION
TLDR; Replaced `font: "Liberation Sans"` with `font: ("Arial", "Liberation Sans")` in `src/covers.typ`

The [`front` option in `text`](https://typst.app/docs/reference/text/text/#parameters-font) allows an array specifying priority usage of fonts, in case one doesn't exist or doesn't have the correct glyphs. This PR adds Arial as a higher priority font than Liberation Sans for the covers, in case it is available on the system, for maximum conformance.The README section mentioning the substitution has been updated to reflect this. 

Attached is a screenshot with and without this change. Since they are basically the same font, the PDF fonts listing has been included in the screenshot.
<img width="1920" height="1052" alt="image" src="https://github.com/user-attachments/assets/e080878b-5f33-4b3c-a1c8-492565b4a572" />
