### PR TITLE
feat: Coerce singles into arrays where appropriate in entry function

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -146,6 +146,39 @@
   // Document body
   body,
 ) = {
+  // Coerce singles as arrays as a QoL
+  if type(authors) != array {
+    authors = (authors,)
+  }
+
+  if type(supervisors) != array {
+    supervisors = (supervisors,) 
+  }
+
+  if type(national-subject-categories) != array {
+    national-subject-categories = (national-subject-categories,)
+  }
+
+  if type(opponents) != array {
+    opponents = (opponents,)
+  }
+
+  if type(extra-preambles) != array {
+    extra-preambles = (extra-preambles,)
+  }
+
+  if type(doc-extra-keywords) != array {
+    doc-extra-keywords = (doc-extra-keywords,)
+  }
+
+  for (lang, info) in localized-info {
+    let keywords = info.at("keywords")
+    if type(keywords) != array {
+      // for loop makes a copy so the full path must be manually accessed
+      localized-info.at(lang).insert("keywords", (keywords,))
+    }
+  }
+
   let alt-lang = if primary-lang == "en" {
     "sv"
   } else if primary-lang == "sv" {


### PR DESCRIPTION
This PR coerces some of the arguments for `kth-thesis` into arrays if they are already not arrays where appropriate, as a QoL. This is mainly done in the form of:
```typst
if type(value) != array {
    value = (value,)
}
```
With some additional code for nested dictionaries (requires full access path).

Apologies for creating so many small PR's, I end up making these as I go along at using the template. Hopefully they are more helpful than the effort.