### PR TITLE
General conforming 2026

### DIFF
--- a/src/covers.typ
+++ b/src/covers.typ
@@ -1,4 +1,4 @@
-#import "./utils.typ": t
+#import "./utils.typ": font-sans, t
 
 #let front-cover(
   title: "Example Title in Primary Language",
@@ -12,7 +12,7 @@
   {
     set align(center)
     // Prioritize Arial if available, otherwise use Liberation Sans
-    set text(size: 12pt, font: ("Arial", "Liberation Sans"))
+    set text(size: 12pt, font: font-sans)
 
     image("../assets/KTH_logo_RGB_bla.svg", width: 37.45mm)
 
@@ -53,7 +53,7 @@
   margin: (top: 65mm, bottom: 30mm, left: 74pt, right: 35mm),
   {
     // Prioritize Arial if available, otherwise use Liberation Sans
-    set text(size: 12pt, font: ("Arial", "Liberation Sans"))
+    set text(size: 12pt, font: font-sans)
 
     v(1fr)
 

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -23,7 +23,7 @@
     if subtitle != none {
       v(10pt)
 
-      text(size: 18pt, subtitle)
+      text(size: 18pt, strong(subtitle))
     }
 
     v(10mm)
@@ -137,7 +137,7 @@
 #let indices = {
   let styled-outline(title, target: none) = {
     show outline.entry: it => {
-      let entry-indent = (it.level - 1) * 1.5em
+      let entry-indent = (it.level - 1) * 2em
       let colored = text.with(fill: rgb("#cf1e26"))
 
       pad(left: entry-indent, link(it.element.location(), if it.prefix() == none [

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -135,32 +135,70 @@
 }
 
 #let indices = {
-  pagebreak(weak: true, to: "odd")
-  {
+  let styled-outline(title, target: none) = {
+    show outline.entry: it => {
+      let entry-indent = (it.level - 1) * 1.5em
+      let colored = text.with(fill: rgb("#cf1e26"))
+
+      pad(left: entry-indent, link(it.element.location(), if it.prefix() == none [
+        #colored(it.body())
+        #box(width: 1fr, it.fill)
+        #it.page()
+      ] else {
+        let prefix = if it.element.func() == figure {
+          context {
+            let chapter = counter(heading.where(level: 1)).at(it.element.location()).first()
+            let fig-num = counter(figure.where(kind: it.element.kind)).at(it.element.location()).last()
+            colored(numbering("1.1", chapter, fig-num))
+          }
+        } else {
+          colored(it.prefix())
+        }
+        grid(
+          columns: (auto, 1fr),
+          gutter: 0.75em,
+          prefix, [#colored(it.body()) #box(width: 1fr, it.fill) #it.page()],
+        )
+      }))
+    }
+
+    set outline.entry(fill: repeat(text(".", fill: luma(0)), gap: 0.5em))
+
     show outline.entry.where(level: 1): it => {
-      v(1em, weak: true)
+      v(1.5em, weak: true)
       strong(it)
     }
 
-    outline(title: t("table-of-contents"), indent: auto)
+    show heading: set text(size: 1.5em)
+    heading(bookmarked: false, outlined: false, title)
+    v(2.5em)
+    if target == none {
+      show outline.entry.where(level: 1): set outline.entry(fill: none)
+      outline(title: none, indent: auto)
+    } else {
+      outline(title: none, target: target, indent: auto)
+    }
   }
+
+  pagebreak(weak: true, to: "odd")
+  styled-outline(t("table-of-contents"))
 
   let images-target = figure.where(kind: image, outlined: true)
   context if (query(images-target).len() > 0) {
     pagebreak(weak: true, to: "odd")
-    outline(title: t("list-of-figures"), target: images-target)
+    styled-outline(t("list-of-figures"), target: images-target)
   }
 
   let tables-target = figure.where(kind: table, outlined: true)
   context if (query(tables-target).len() > 0) {
     pagebreak(weak: true, to: "odd")
-    outline(title: t("list-of-tables"), target: tables-target)
+    styled-outline(t("list-of-tables"), target: tables-target)
   }
 
   let code-target = figure.where(kind: raw, outlined: true)
   context if (query(code-target).len() > 0) {
     pagebreak(weak: true, to: "odd")
-    outline(title: t("list-of-listings"), target: code-target)
+    styled-outline(t("list-of-listings"), target: code-target)
   }
 }
 

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -36,8 +36,8 @@
     v(1fr)
 
     [
-      *#degree* \
-      *#t("date"):* #date.display("[month repr:long] [day], [year]")
+      #degree \
+      #t("date"): #date.display("[month repr:long] [day], [year]")
     ]
 
     v(5mm)
@@ -49,25 +49,25 @@
     }
 
     [
-      *#super-label:* #join-names(supervisors) \
-      *#t("examiner"):* #examiner-name \
-      #hide[*#t("examiner"):*] #emph(examiner-school) \
+      #super-label: #join-names(supervisors) \
+      #t("examiner"): #examiner-name \
+      #hide[#t("examiner"):] #emph(examiner-school) \
     ]
 
     if host-company != none {
-      [*#t("host-company"):* #host-company]
+      [#t("host-company"): #host-company]
       linebreak()
     }
 
     if host-org != none {
-      [*#t("host-org"):* #host-org]
+      [#t("host-org"): #host-org]
       linebreak()
     }
 
     [
-      *#t("alt-title"):* #text(lang: alt-lang, alt-title) \
+      #t("alt-title"): #text(lang: alt-lang, alt-title) \
       #if alt-subtitle != none {
-        [*#t("alt-subtitle"):* #text(lang: alt-lang, alt-subtitle)]
+        [#t("alt-subtitle"): #text(lang: alt-lang, alt-subtitle)]
       }
     ]
   },

--- a/src/front-matter.typ
+++ b/src/front-matter.typ
@@ -1,4 +1,4 @@
-#import "./utils.typ": join-names, t
+#import "./utils.typ": font-sans, join-names, t
 
 #let title-page(
   title: "Primary Language Title Goes Here",
@@ -17,6 +17,7 @@
 ) = page(
   margin: (top: 65mm, bottom: 30mm, left: 74pt, right: 35mm),
   {
+    set text(size: 12pt, font: font-sans)
     text(size: 25pt, strong(title))
 
     if subtitle != none {
@@ -78,6 +79,7 @@
 ) = page(
   margin: (top: 250mm, bottom: 30mm, left: 74pt, right: 35mm),
   {
+    set text(font: font-sans)
     v(1fr)
 
     [#sym.copyright #year #sym.space.quad #join-names(authors)]

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -168,6 +168,7 @@
   )
   set page("a4")
   set text(lang: primary-lang, size: 12pt)
+  show heading: set block(above: 1.75em, below: 1em) // Margin above and below headings
 
   front-cover(
     title: primary-info.at("title"),

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -213,7 +213,7 @@
           info.at("abstract"),
         ),
       )
-      page(header: none, footer: none, []) // blank
+      page[] // blank
     }
 
     page(

--- a/src/styling-setup.typ
+++ b/src/styling-setup.typ
@@ -45,7 +45,7 @@
 }
 
 #let styled-body(body) = {
-  set heading(numbering: "1.1.", supplement: t("section"))
+  set heading(numbering: "1.1", supplement: t("section"))
 
   show heading: set text(size: 12pt) // for level > 3
   show heading.where(level: 1): set text(size: 25pt)
@@ -64,11 +64,12 @@
     if it.numbering == none {
       it.body
     } else {
-      let numbering = it.numbering.slice(0, -1) // remove trailing .
-      let number = counter(heading).display(numbering)
+      let number = counter(heading).display(it.numbering)
 
       [
         #it.supplement #number \
+
+        // intentional newline above for extra spacing
         #it.body
       ]
 
@@ -90,7 +91,7 @@
 }
 
 #let setup-appendices(body) = {
-  set heading(numbering: "A.1.")
+  set heading(numbering: "A.1")
   counter(heading).update(0)
   show heading.where(level: 1): set heading(supplement: t("appendix"))
 

--- a/src/styling-setup.typ
+++ b/src/styling-setup.typ
@@ -1,10 +1,10 @@
-#import "./utils.typ": kth-blue, t
+#import "./utils.typ": font-sans, kth-blue, t
 
 #import "@preview/headcount:0.1.0": dependent-numbering
 #import "@preview/hydra:0.6.1": hydra
 
 #let header() = context {
-  set text(font: ("Arial", "Liberation Sans"))
+  set text(font: font-sans)
   
   let chapter = hydra(1, skip-starting: false, display: (ctx, h) => h.body)
 
@@ -29,7 +29,7 @@
 
   set par(justify: true)
 
-  show heading: set text(font: ("Arial", "Liberation Sans"))
+  show heading: set text(font: font-sans)
 
   // front matter only; essentially styles [h1 as h2] and [h2 as h3]
   show heading.where(level: 1): set text(size: 18pt)

--- a/src/styling-setup.typ
+++ b/src/styling-setup.typ
@@ -4,6 +4,8 @@
 #import "@preview/hydra:0.6.1": hydra
 
 #let header() = context {
+  set text(font: ("Arial", "Liberation Sans"))
+  
   let chapter = hydra(1, skip-starting: false, display: (ctx, h) => h.body)
 
   let number = counter(page).display(here().page-numbering())
@@ -26,6 +28,8 @@
   )
 
   set par(justify: true)
+
+  show heading: set text(font: ("Arial", "Liberation Sans"))
 
   // front matter only; essentially styles [h1 as h2] and [h2 as h3]
   show heading.where(level: 1): set text(size: 18pt)

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -5,6 +5,8 @@
 
 #let lang-db = toml("./lang.toml")
 
+#let font-sans = ("Arial", "Liberation Sans")
+
 #let t = key => linguify(key, from: lang-db)
 
 #let get-one-liner(lang, info) = {


### PR DESCRIPTION
I really enjoy this repo and forked it to better conform to — at least what I've seen — the LaTeX template KTH is currently handing out. I thought I may as well share it in case you wish to integrate these changes into the Typst template.

Here's the changes and comparisons to master branch as well as **a newly released paper using the current KTH LaTeX template**.

## Front Page
- Use sans-serif font,
- Bold styling of subtitle,
- Remove bold styling of all headers for fields such as programme, date, supervisors, etc.
#### This branch vs Master
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/befa148f-b0ed-4aab-a776-5522de5dca9d" />

#### This branch vs a Reference Paper
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/97a6823b-19f7-4968-991b-4f9662c6bf4b" />

## Tables of Contents etc.
Affects all `outline()`-calls that produce table of contents (headings, images, tables, and listings)
- Increase title prominence,
- Increase gap between filler-dots,
- Color links in red — I have no idea why KTH wants to have it this way but who am I to judge...
  - This code needs extra attention since it manually overrides each outline.entry styling.

#### This branch vs Master
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ed6be2aa-ec74-495b-9914-c3641305541c" />

#### This branch vs a Reference Paper
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6e02a176-f291-415c-b469-b0efe94dbe9b" />

## General Heading Improvements
- Use sans-serif font for headings **and headers**,
- Remove trailing "." in numbering,
- New chapters have additional vertical space below, before the actual heading,

#### This branch vs Master
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c8a0b34d-f5e7-4272-9b87-80a51ba15282" />

#### This branch vs a Reference Paper
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a2463cf7-903f-415b-ac4f-1527dad43119" />

## Future work *not in this PR*

As you may notice in the reference paper, there's additional whitespace above section titles as well as above TOC-headers. I have a fix for that as well but it would involve dropping hydra:0.6.1 as a dependency, and hand-rolling a custom chapter-getter as such:

```diff
-#import "@preview/hydra:0.6.1": hydra
 
 #let header() = context {
   set text(font: font-sans)
-  
-  let chapter = hydra(1, skip-starting: false, display: (ctx, h) => h.body)
+
+  let headings = query(heading.where(level: 1))
+  let pg = here().page()
+  let chapter = {
+    let on-page = headings.filter(h => h.location().page() == pg)
+    if on-page.len() > 0 {
+      on-page.first().body
+    } else {
+      let before-page = headings.filter(h => h.location().page() < pg)
+      if before-page.len() > 0 { before-page.last().body } else { [] }
+    }
+  }
```

This works fine, I'll be using it for my own thesis but I'm a bit cautious about including it here as well since I'm unsure of the edge-cases which hydra handles on its own.

#### Comparison of that Future Work vs a Reference Paper

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/e459ba7d-079d-432d-870a-388ae934938a" />
