### PR TITLE
feat: add support for cover image

### DIFF
--- a/src/covers.typ
+++ b/src/covers.typ
@@ -42,6 +42,12 @@
       strong(upper(author))
       linebreak()
     }
+
+    v(4em)
+
+    if style.cover-image != none {
+      image(style.cover-image, width: style.image-size.width, height: style.image-size.height)
+    }
   },
 )
 

--- a/src/covers.typ
+++ b/src/covers.typ
@@ -43,10 +43,12 @@
       linebreak()
     }
 
+    // 800 twips (40pt) of vertical space, 120 twips after author and 680 twips before image
+    // as per official KTH cover template
     v(40pt)
 
     if style.cover-image != none {
-      image(style.cover-image, width: style.image-size.width, height: style.image-size.height)
+      style.cover-image
     }
   },
 )

--- a/src/covers.typ
+++ b/src/covers.typ
@@ -43,7 +43,7 @@
       linebreak()
     }
 
-    v(4em)
+    v(40pt)
 
     if style.cover-image != none {
       image(style.cover-image, width: style.image-size.width, height: style.image-size.height)

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -153,6 +153,8 @@
       more-sans-serif: false,
       use-arial: false,
       fancy-chapters: false,
+      cover-image: none,
+      image-size: (width: 16.7cm, height: 9.2cm), // Default image size is same as placeholder in KTH cover
     )
       + style // provided values have higher precedence over default values
   )

--- a/src/lib.typ
+++ b/src/lib.typ
@@ -154,7 +154,6 @@
       use-arial: false,
       fancy-chapters: false,
       cover-image: none,
-      image-size: (width: 16.7cm, height: 9.2cm), // Default image size is same as placeholder in KTH cover
     )
       + style // provided values have higher precedence over default values
   )

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -166,8 +166,8 @@
     more-sans-serif: false,
     // Whether to make top-level headings stand out more and look less plain
     fancy-chapters: false,
-    // Add path to cover image to use on the cover page
-    //  Size of the cover image can be adjusted using `image-size`(optional)
+    // Pass cover image using the typst `image` function, e.g.
+    // cover-image: image("image.png", width: 16cm, height: 10cm)
     cover-image: none,
   ),
 )

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -3,7 +3,7 @@
 // The template is extensible and plays well with other dependencies;
 // For example, a table of acronyms can be generated using glossarium
 #import "@preview/glossarium:0.5.10": (
-  make-glossary, print-glossary, register-glossary
+  make-glossary, print-glossary, register-glossary,
 )
 #import "./acronyms.typ": acronyms
 #show: make-glossary

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -2,9 +2,7 @@
 
 // The template is extensible and plays well with other dependencies;
 // For example, a table of acronyms can be generated using glossarium
-#import "@preview/glossarium:0.5.10": (
-  make-glossary, print-glossary, register-glossary,
-)
+#import "@preview/glossarium:0.5.10": make-glossary, print-glossary, register-glossary
 #import "./acronyms.typ": acronyms
 #show: make-glossary
 #register-glossary(acronyms)
@@ -168,6 +166,9 @@
     more-sans-serif: false,
     // Whether to make top-level headings stand out more and look less plain
     fancy-chapters: false,
+    // Add path to cover image to use on the cover page
+    //  Size of the cover image can be adjusted using `image-size`(optional)
+    cover-image: none,
   ),
 )
 

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -2,7 +2,9 @@
 
 // The template is extensible and plays well with other dependencies;
 // For example, a table of acronyms can be generated using glossarium
-#import "@preview/glossarium:0.5.10": make-glossary, print-glossary, register-glossary
+#import "@preview/glossarium:0.5.10": (
+  make-glossary, print-glossary, register-glossary
+)
 #import "./acronyms.typ": acronyms
 #show: make-glossary
 #register-glossary(acronyms)


### PR DESCRIPTION
Hello, 

I am using this template for my thesis project and I love the work you have done on it. The only thing that I felt was missing is adding support for a cover image as supported by the original KTH cover. 

The cover image and image size are added as style parameters.  I inspected the size of the cover image in the DOTX template as a sane image size default.

I have tested that it works, it looks like this:  

<img width="992" height="977" alt="image" src="https://github.com/user-attachments/assets/ee2c534c-f07c-4e72-ae9b-8e916e0f4f01" />
Best, 
Abhinav